### PR TITLE
Set modifier category to NONE if there are no categories

### DIFF
--- a/src/main/java/net/joseph/ccvault/peripheral/custom/VaultReaderBlockPeripheral.java
+++ b/src/main/java/net/joseph/ccvault/peripheral/custom/VaultReaderBlockPeripheral.java
@@ -159,7 +159,7 @@ public class VaultReaderBlockPeripheral extends TweakedPeripheral<VaultReaderBlo
     public Optional<MutableComponent> getDisplay(VaultGearModifier modifier,VaultGearData data, VaultGearModifier.AffixType type, ItemStack stack, boolean displayDetail) {
         boolean isCL;
         VaultGearModifier.AffixCategory cat;
-        if (modifier.hasCategory(VaultGearModifier.AffixCategory.LEGENDARY)  || modifier.hasCategory(VaultGearModifier.AffixCategory.CRAFTED)) {
+        if (modifier.getCategories().isEmpty() || modifier.hasCategory(VaultGearModifier.AffixCategory.LEGENDARY) || modifier.hasCategory(VaultGearModifier.AffixCategory.CRAFTED)) {
             cat = VaultGearModifier.AffixCategory.NONE;
         } else {
             cat = modifier.getCategories().first();


### PR DESCRIPTION
If a modifier does not have any categories, `modifier.getCategories().first()` will fail. We just set the category to `NONE` in that case.