### PR TITLE
fix `Vanilla Immortality` always returning 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.1.3-3.15'
+version = '1.1.3.1-3.15'
 group = 'com.joseph.ccvault' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'ccvault'
 

--- a/src/main/java/net/joseph/ccvault/peripheral/custom/VaultReaderBlockPeripheral.java
+++ b/src/main/java/net/joseph/ccvault/peripheral/custom/VaultReaderBlockPeripheral.java
@@ -360,7 +360,7 @@ public class VaultReaderBlockPeripheral extends TweakedPeripheral<VaultReaderBlo
             }
         }
         if (modifier.contains("IV")) {return 4;}
-        if (modifier.contains("V")) {return 5;}
+        if (modifier.contains("V ")) {return 5;}
         if (modifier.contains("III")) {return 3;}
         if (modifier.contains("II")) {return 2;}
 


### PR DESCRIPTION
the code to catch the `.. V Cloud` affixes in `getModifierValue()` was accidentally also hitting `Vanilla Immortality`, causing any test against the latter to return `5.0` instead of its actual value